### PR TITLE
Fix for executing endecrypt in dockerfile

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,7 @@ var util = {};
 util.setRawMode = function(mode) {
     if (process.stdin.setRawMode) {
         process.stdin.setRawMode(mode);
-    } else {
+    } else if (process.stdin.isTTY) {
         tty.setRawMode(mode);
     }
 };


### PR DESCRIPTION
When executed from a dockerfile, the encrypt/decrypt commands raise the following exception:

~~~
TypeError: tty.setRawMode is not a function
~~~

This PR adds a check before executing the setRawMode.